### PR TITLE
References against libm should go to the end of the command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ $(TARGET_LIB): $(OBJS)
 	$(CC) ${LDFLAGS} -o $@ $^
 
 dev: pico-tts.c $(TARGET_LIB)
-	$(CC) -g -Wall -Wextra -O2 -g -I $(LIB_DIR) -L. -l svoxpico -Wl,-rpath=. -o $@ $^ -lm
+	$(CC) -g -Wall -Wextra -O2 -g -Wl,-rpath=. -o $@ $^ -I $(LIB_DIR) -L. -l svoxpico -lm
 
 pico-tts: pico-tts.c $(TARGET_LIB)
-	$(CC) -g -Wall -Wextra -O2 -g -I $(LIB_DIR) -L. -l svoxpico -DNDEBUG -o $@ $^ -lm
+	$(CC) -g -Wall -Wextra -O2 -g -DNDEBUG -o $@ $^ -I $(LIB_DIR) -L. -l svoxpico -lm
 
 install: pico-tts
 	install -D -s -t $(DESTDIR)/usr/lib/ ${TARGET_LIB}

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ $(TARGET_LIB): $(OBJS)
 	$(CC) ${LDFLAGS} -o $@ $^
 
 dev: pico-tts.c $(TARGET_LIB)
-	$(CC) -g -Wall -Wextra -O2 -g -I $(LIB_DIR) -lm -L. -l svoxpico -Wl,-rpath=. -o $@ $^
+	$(CC) -g -Wall -Wextra -O2 -g -I $(LIB_DIR) -L. -l svoxpico -Wl,-rpath=. -o $@ $^ -lm
 
 pico-tts: pico-tts.c $(TARGET_LIB)
-	$(CC) -g -Wall -Wextra -O2 -g -I $(LIB_DIR) -lm -L. -l svoxpico -DNDEBUG -o $@ $^
+	$(CC) -g -Wall -Wextra -O2 -g -I $(LIB_DIR) -L. -l svoxpico -DNDEBUG -o $@ $^ -lm
 
 install: pico-tts
 	install -D -s -t $(DESTDIR)/usr/lib/ ${TARGET_LIB}


### PR DESCRIPTION
On Ubuntu, the build fails at the linking stage because it can't find the math functions even though the math library libm is used. 

In order to fix that, the `-lm` flag should be moved to the end.